### PR TITLE
Update dependencies of the SDK to latest

### DIFF
--- a/duo-universal-sdk/pom.xml
+++ b/duo-universal-sdk/pom.xml
@@ -105,44 +105,44 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.5.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>2.1.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.20</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.11.3</version>
+            <version>2.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.3.0</version>
+            <version>3.18.1</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
-            <version>3.3.1</version>
+            <version>4.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.3.2</version>
+            <version>5.7.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.6.28</version>
+            <version>3.11.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
@@ -33,18 +33,14 @@ public class Utils {
   static String createJwt(String clientId, String clientSecret, String aud) throws DuoException {
     Date expiration = new Date();
     expiration.setTime(expiration.getTime() + ONE_HOUR_IN_MILLISECONDS);
-    try {
-      return JWT.create()
-                  .withHeader(HEADERS)
-                  .withIssuer(clientId)
-                  .withSubject(clientId)
-                  .withAudience(aud)
-                  .withExpiresAt(expiration)
-                  .withJWTId(generateJwtId(32))
-                  .sign(Algorithm.HMAC512(clientSecret));
-    } catch (UnsupportedEncodingException e) {
-      throw new DuoException(e.getMessage(), e);
-    }
+    return JWT.create()
+            .withHeader(HEADERS)
+            .withIssuer(clientId)
+            .withSubject(clientId)
+            .withAudience(aud)
+            .withExpiresAt(expiration)
+            .withJWTId(generateJwtId(32))
+            .sign(Algorithm.HMAC512(clientSecret));
   }
 
   static String createJwtForAuthUrl(String clientId, String clientSecret, String redirectUri,
@@ -52,21 +48,17 @@ public class Utils {
                                     Boolean useDuoCodeAttribute) throws DuoException {
     Date expiration = new Date();
     expiration.setTime(expiration.getTime() + ONE_HOUR_IN_MILLISECONDS);
-    try {
-      return JWT.create()
-                  .withHeader(HEADERS)
-                  .withExpiresAt(expiration)
-                  .withClaim("scope", "openid")
-                  .withClaim("client_id", clientId)
-                  .withClaim("redirect_uri", redirectUri)
-                  .withClaim("state", state)
-                  .withClaim("duo_uname", username)
-                  .withClaim("response_type", "code")
-                  .withClaim("use_duo_code_attribute", useDuoCodeAttribute)
-                  .sign(Algorithm.HMAC512(clientSecret));
-    } catch (UnsupportedEncodingException e) {
-      throw new DuoException(e.getMessage(), e);
-    }
+    return JWT.create()
+            .withHeader(HEADERS)
+            .withExpiresAt(expiration)
+            .withClaim("scope", "openid")
+            .withClaim("client_id", clientId)
+            .withClaim("redirect_uri", redirectUri)
+            .withClaim("state", state)
+            .withClaim("duo_uname", username)
+            .withClaim("response_type", "code")
+            .withClaim("use_duo_code_attribute", useDuoCodeAttribute)
+            .sign(Algorithm.HMAC512(clientSecret));
   }
 
   static Token transformDecodedJwtToToken(DecodedJWT decodedJwt) {


### PR DESCRIPTION
Doesn't touch the example, but that's probably worth a pass.

Code changes were necessary because java-jwt inadvertently made a backwards-incompatible change in 3.4.0: https://github.com/auth0/java-jwt/issues/376