### PR TITLE
Fix redirect_uri not being URL encoded.

### DIFF
--- a/duo-universal-sdk/src/main/java/com/duosecurity/Client.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Client.java
@@ -10,6 +10,10 @@ import static com.duosecurity.Validator.validateState;
 import static com.duosecurity.Validator.validateUsername;
 import static java.lang.String.format;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.duosecurity.exception.DuoException;
 import com.duosecurity.model.HealthCheckResponse;
@@ -275,9 +279,14 @@ public class Client {
     validateState(state);
     String request = createJwtForAuthUrl(clientId, clientSecret, redirectUri,
             state, username, useDuoCodeAttribute);
-    String query = format(
-            "?scope=openid&response_type=code&redirect_uri=%s&client_id=%s&request=%s",
-            redirectUri, clientId, request);
+    String query;
+	try {
+		query = format(
+		        "?scope=openid&response_type=code&redirect_uri=%s&client_id=%s&request=%s",
+		        URLEncoder.encode(redirectUri, StandardCharsets.UTF_8.toString()), clientId, request);
+	} catch (UnsupportedEncodingException e) {
+		throw new IllegalStateException("Could not find encoding: " + StandardCharsets.UTF_8.toString());
+	}
     return getAndValidateUrl(apiHost, OAUTH_V_1_AUTHORIZE_ENDPOINT + query).toString();
   }
 

--- a/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
@@ -15,8 +15,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Matchers.any;
@@ -79,12 +82,12 @@ class ClientTest {
     }
 
     @Test
-    void createAuthUrl_success() throws DuoException {
+    void createAuthUrl_success() throws DuoException, UnsupportedEncodingException {
         String urlString = client.createAuthUrl(USERNAME, STATE);
         try {
             URL authUrl = new URL(urlString);
             assertEquals(authUrl.getHost(), API_HOST);
-            assertTrue(authUrl.getQuery().contains("redirect_uri=" + HTTPS_REDIRECT_URI));
+            assertTrue(authUrl.getQuery().contains("redirect_uri=" + URLEncoder.encode(HTTPS_REDIRECT_URI, StandardCharsets.UTF_8.toString())));
             assertTrue(authUrl.getQuery().contains("client_id=" + CLIENT_ID));
             assertTrue(authUrl.getProtocol().equals("https"));
         } catch (MalformedURLException e) {


### PR DESCRIPTION
All other parameters don't need URL encoding, but redirect_uri contains colons, slashes, query parameters of its own.
Duo's server manages to parse the request correctly either way (which explains why this fix is not essential) but this should be corrected.