### PR TITLE
Bump jackson-core and logging-interceptor versions

### DIFF
--- a/duo-example/pom.xml
+++ b/duo-example/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 

--- a/duo-universal-sdk/pom.xml
+++ b/duo-universal-sdk/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.12.4</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
-            <version>4.9.1</version>
+            <version>4.9.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION

## Description
Older versions of jackson-databind (part of jackson-core) and logging-interceptor are vulnerable to a variety of OWASP-acknowledged exploits, including [CVE-2023-35116](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-35116), [CVE-2022-42004](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42004), [CVE-2021-46877](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-46877), and [CVE-2023-0833](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-0833). Both of those libraries are leveraged by duo_universal_java. This MR upgrades the dependencies to versions without those vulnerabilities.

I acknowledge that the [security policy](https://github.com/duosecurity/duo_universal_java/blob/5c89d6d6a20151d2dbb4b9109584aa2fe62d7a02/SECURITY.md) stipulates that vulnerabilities should be reported to Duo first; however, as this is an acknowledged (and patched) vulnerability in dependencies rather than the project's source code itself, I am simply opening an MR. Doing otherwise after I realized this issue exists would be security through obscurity, rather than actually solving the problem. Better to get this fixed ASAP.

## Motivation and Context
duo_universal_java is currently open to a variety of exploits, including resource exhaustion, DOS, and XXE attacks. That is concerning. As a user (and enjoyer) of this project, I'd like to patch those vulnerabilities with this MR.

## How Has This Been Tested?
All currently extant unit tests passed; beyond that, my ability to test is limited.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
