### PR TITLE
Specified version of maven-assembly-plugin

### DIFF
--- a/duo-universal-sdk/pom.xml
+++ b/duo-universal-sdk/pom.xml
@@ -157,6 +157,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.4</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Specified version of maven-assembly-plugin in pom.xml

## Motivation and Context
The build of duo_universal_duo fails with the following message:

Could not find goal 'attached' in plugin org.apache.maven.plugins:maven-assembly-plugin:3.7.1 among available goals help, single.

This issue occurs because the version of maven-assembly-plugin is not specified in the pom.xml, and the goal 'attached' is deprecated in the latest version of the package.

## How Has This Been Tested?
Specified the version number used in the application.

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
