### PR TITLE
Explicitly specified byte-buddy version to 1.15.4 to ensure compatibi…

### DIFF
--- a/duo-universal-sdk/pom.xml
+++ b/duo-universal-sdk/pom.xml
@@ -129,6 +129,11 @@
             <version>3.11.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.15.4</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description
Explicitly specified byte-buddy version to 1.15.4 to ensure compatibility with Java 21

## Motivation and Context
Tests were failing to build on Java 21 due to compatibility issues with the version of byte-buddy previously used. Updating to version 1.15.4 resolves these issues by ensuring that dynamic agent loading works correctly.

## How Has This Been Tested?
- Ran the full test suite on Java 21, and all tests passed successfully.
- Verified that no other parts of the application were affected by this change.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
