### PR TITLE
[ZTAT-947] Add more Java versions to CI

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -14,7 +14,7 @@ jobs:
 
      strategy:
        matrix:
-        java-version: [1.8, 11, 17, 21, 23]
+        java-version: [1.8, 11, 17, 21]
 
      steps:
        - uses: actions/checkout@v2

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -11,21 +11,32 @@ jobs:
    build-and-test:
      name: Java CI - test
      runs-on: ubuntu-latest
+
+     strategy:
+       matrix:
+        java-version: [1.8, 11, 17, 21, 23]
+
      steps:
        - uses: actions/checkout@v2
+
        - name: Set up Java
          uses: actions/setup-java@v1
          with:
-           java-version: 1.8
+           java-version: ${{ matrix.java-version }}
+
        - name: Inject dummy example config
          working-directory: duo-example
          run: printf "duo.clientId=DIAAAAAAAAAAAAAAAAAA\nduo.clientSecret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nduo.api.host=example.duosecurity.com\nduo.redirect.uri=http://localhost:8080\nduo.failmode=CLOSED\n" > ./src/main/resources/application.properties
+       
        - name: Build and test with Maven
          run: mvn -B install
+       
        - name: Lint with checkstyle
          run: mvn checkstyle:check
+       
        - name: Verify example starts
          working-directory: duo-example
          run: mvn spring-boot:start
+       
        - name: Verify release profile works
          run: mvn -P release package


### PR DESCRIPTION
## Description
This PR adds Java versions 11, 17, 21 and 23 to the CI configuration.

## Motivation and Context
[Jira task](https://cisco-sbg.atlassian.net/browse/ZTAT-947)

## How Has This Been Tested?
Ran tests locally with different Java versions.

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
