### PR TITLE
Change spring-webmvc version

### DIFF
--- a/duo-example/pom.xml
+++ b/duo-example/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>5.3.18</version>
+            <version>5.3.24</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Description
This PR changes the Spring Web MVC version from `5.3.18` to `5.3.24`. 

## Motivation and Context
Avoid [PR #40](https://github.com/duosecurity/duo_universal_java/pull/40)'s backwards compatibility issue.

## How Has This Been Tested?
CI passing.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
