### PR TITLE
Configure OkHttp connection pool with 55s keep-alive

### DIFF
--- a/duo-universal-sdk/src/main/java/com/duosecurity/service/DuoConnector.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/service/DuoConnector.java
@@ -8,7 +8,9 @@ import com.duosecurity.model.TokenResponse;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.util.concurrent.TimeUnit;
 import okhttp3.CertificatePinner;
+import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import retrofit2.Call;
 import retrofit2.Response;
@@ -20,6 +22,19 @@ public class DuoConnector {
   protected Retrofit retrofit;
 
   private static final int SUCCESS_STATUS_CODE = 200;
+
+  /**
+   * Maximum number of idle connections to keep in the pool.
+   * 5 is the OkHttp default, and reasonable for our needs.
+   */
+  private static final int MAX_IDLE_CONNECTIONS = 5;
+
+  /**
+   * How long to keep idle connections alive before closing them. The Duo service closes
+   * connections server-side after 1 minute, so we close them slightly earlier to avoid
+   * holding on to a stale connection.
+   */
+  private static final int CONNECTION_KEEP_ALIVE_SECONDS = 55;
 
   /**
    * DuoConnector Constructor.
@@ -47,16 +62,20 @@ public class DuoConnector {
           throws DuoException {
     CertificatePinner duoCertificatePinner = new CertificatePinner.Builder()
             .add(apiHost, caCerts).build();
+    ConnectionPool connectionPool = new ConnectionPool(
+            MAX_IDLE_CONNECTIONS, CONNECTION_KEEP_ALIVE_SECONDS, TimeUnit.SECONDS);
     OkHttpClient client;
     if (proxyHost != null && proxyPort != null) {
       Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
       client = new OkHttpClient.Builder()
               .certificatePinner(duoCertificatePinner)
+              .connectionPool(connectionPool)
               .proxy(proxy)
               .build();
     } else {
       client = new OkHttpClient.Builder()
               .certificatePinner(duoCertificatePinner)
+              .connectionPool(connectionPool)
               .build();
     }
 


### PR DESCRIPTION
## Description
Resolves #51 

Duo's services close the remote side of a connection after about one minute of idle. OkHttp defaults to a keep-alive timeout of 5 minutes and does not check for closed connections until that timeout. As a result, any connection left in the pool will sit in a `CLOSE-WAIT` state for ~4 minutes before it is fully closed and evicted.

This change updates the OkHttp connection pool to use a keep-alive of 55 seconds so that we cleanly close those connections before they get stale.

## Motivation and Context
There is no advantage to trying to maintain an idle connection to Duo's services for longer than 60 seconds, since the server-side will sever the connection. The connection pool still works properly with a longer timeout, but in times of low traffic, can end up leaving sockets sitting in `CLOSE-WAIT` for several minutes. It is better hygiene to close these out sooner.

## How Has This Been Tested?
Ran the `duo-example` springboot app, authing several times, and then watching the socket state with `lsof -p <springboot pid> | grep TCP | grep ec2`.

_Before this change_, we can see the socket to Duo's service entering `CLOSE-WAIT` after ~1 minute of idle time and then get completely closed after another ~4 minutes.

_After this change_, we can see the socket to Duo's service get completely closed after ~55 seconds of idle time and never sits in the `CLOSE-WAIT` state.

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
