### PR TITLE
Migrate Maven Central publishing from OSSRH to Central Portal

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -14,14 +14,15 @@ jobs:
 
      strategy:
        matrix:
-        java-version: [1.8, 11, 17, 21]
+        java-version: [8, 11, 17, 21]
 
      steps:
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
        - name: Set up Java
-         uses: actions/setup-java@v1
+         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
          with:
+           distribution: 'temurin'
            java-version: ${{ matrix.java-version }}
 
        - name: Inject dummy example config

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -7,16 +7,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
-        java-version: 1.8
+        java-version: '11'
+        distribution: 'temurin'
 
     - name: Build with Maven
       run: mvn -B package
-    
+
     - name: Generate sbom output
       run: mvn org.cyclonedx:cyclonedx-maven-plugin:makeBom && mv ./duo-universal-sdk/target/cyclonedx-sbom.json ./cyclonedx-sbom.json
 
@@ -24,16 +25,17 @@ jobs:
       uses: duosecurity/duo_client_python/.github/actions/sbom-convert@master
 
     - name: Archive SBOM artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: duo_universal_java_sbom
         path: spdx.json
 
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
-        java-version: 1.8
-        server-id: ossrh
+        java-version: '11'
+        distribution: 'temurin'
+        server-id: central
         server-username: MAVEN_USERNAME # env variable for username in deploy
         server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import

--- a/duo-universal-sdk/pom.xml
+++ b/duo-universal-sdk/pom.xml
@@ -35,23 +35,21 @@
             <id>release</id>
             <build>
                 <plugins>
-                    <!-- This is used to release our package to OSSHR and Maven -->
+                    <!-- This is used to release our package to Maven Central via the Central Portal -->
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                           <serverId>ossrh</serverId>
-                           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                           <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                           <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                     <!-- This plugin is used to sign our package with our GPG keys -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.2.7</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -72,7 +70,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -86,7 +84,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.11.2</version>
                         <executions>
                             <execution>
                               <id>attach-javadocs</id>


### PR DESCRIPTION
Replace the deprecated nexus-staging-maven-plugin with central-publishing-maven-plugin 0.9.0. Update GitHub Actions (checkout v4, setup-java v4) and bump JDK to 11 in the deploy workflow. Bump maven-gpg-plugin, maven-source-plugin, and maven-javadoc-plugin to current versions. Pin all public GitHub Actions to commit SHAs in both CI and deploy workflows.

## Motivation and Context
Migrate to the new Maven deployment process

## How Has This Been Tested?
Tested to the point where I'd need to do a real release.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Release management
