### PR TITLE
Remove redundant jackson-core override from example app

### DIFF
--- a/duo-example/pom.xml
+++ b/duo-example/pom.xml
@@ -74,12 +74,6 @@
             <version>4.6.1</version>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.16.0</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary

- Removes the direct `jackson-core:2.16.0` dependency from `duo-example/pom.xml`, letting Spring Boot's BOM manage all jackson artifacts consistently
- This pin existed since the initial commit (2020) and was never intentional — it created a version mismatch: jackson-core 2.16.0 vs jackson-databind 2.13.5 (managed by Spring Boot 2.6.15)
- The SDK is unaffected — it gets jackson transitively via Retrofit's `converter-jackson` and has no Spring dependency

## Test plan

- [ ] CI passes (`mvn install`, checkstyle, `spring-boot:start` across Java 8/11/17/21)
- [ ] Verify jackson versions are now consistent in `duo-example` dependency tree

## Note

A follow-up Spring Boot 3.x upgrade will address the remaining Dependabot alerts (including the jackson-core async parser DoS and the 5 spring-webmvc issues with no fix in Spring 5.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)