### PR TITLE
Add amr claim to Token model

### DIFF
--- a/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
@@ -76,6 +76,7 @@ public class Utils {
     token.setAuth_time(decodedJwt.getClaim("auth_time").asInt());
     token.setExp(decodedJwt.getClaim("exp").asInt());
     token.setSub(decodedJwt.getClaim("sub").asString());
+    token.setAmr(decodedJwt.getClaim("amr").asList(String.class));
     return token;
   }
 

--- a/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
@@ -4,6 +4,8 @@ import static java.lang.String.format;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.duosecurity.exception.DuoException;
 import com.duosecurity.model.AccessDevice;
@@ -19,6 +21,7 @@ import java.net.URL;
 import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 public class Utils {
@@ -76,8 +79,17 @@ public class Utils {
     token.setAuth_time(decodedJwt.getClaim("auth_time").asInt());
     token.setExp(decodedJwt.getClaim("exp").asInt());
     token.setSub(decodedJwt.getClaim("sub").asString());
-    token.setAmr(decodedJwt.getClaim("amr").asList(String.class));
+    token.setAmr(extractAmr(decodedJwt.getClaim("amr")));
     return token;
+  }
+
+  private static List<String> extractAmr(Claim amrClaim) {
+    try {
+      return amrClaim.asList(String.class);
+    } catch (JWTDecodeException e) {
+      // Non-string array elements (RFC 8176 violation) — treat as absent.
+      return null;
+    }
   }
 
   static boolean validateCaCert(String[] userCaCerts) {

--- a/duo-universal-sdk/src/main/java/com/duosecurity/model/Token.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/model/Token.java
@@ -1,6 +1,7 @@
 package com.duosecurity.model;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 public class Token implements Serializable {
@@ -15,6 +16,7 @@ public class Token implements Serializable {
   private Integer auth_time;
   private AuthResult auth_result;
   private AuthContext auth_context;
+  private List<String> amr;
 
   /**
    * Constructor with all properties.
@@ -121,6 +123,14 @@ public class Token implements Serializable {
     this.auth_context = authContext;
   }
 
+  public List<String> getAmr() {
+    return amr;
+  }
+
+  public void setAmr(List<String> amr) {
+    this.amr = amr;
+  }
+
   @Override
   public String toString() {
     return "Token [iss=" + iss
@@ -132,6 +142,7 @@ public class Token implements Serializable {
           + ", auth_time=" + auth_time
           + ", auth_result=" + auth_result
           + ", auth_context=" + auth_context
+          + ", amr=" + amr
           + ", getAud()=" + getAud()
           + ", getAuth_context()=" + getAuth_context()
           + ", getAuth_result()=" + getAuth_result()
@@ -167,7 +178,8 @@ public class Token implements Serializable {
         && Objects.equals(iat, other.iat)
         && Objects.equals(auth_time, other.auth_time)
         && Objects.equals(auth_result, other.auth_result)
-        && Objects.equals(auth_context, other.auth_context);
+        && Objects.equals(auth_context, other.auth_context)
+        && Objects.equals(amr, other.amr);
   }
 
   @Override
@@ -183,6 +195,7 @@ public class Token implements Serializable {
     result = prime * result + ((auth_time == null) ? 0 : auth_time.hashCode());
     result = prime * result + ((auth_result == null) ? 0 : auth_result.hashCode());
     result = prime * result + ((auth_context == null) ? 0 : auth_context.hashCode());
+    result = prime * result + ((amr == null) ? 0 : amr.hashCode());
     return result;
   }
 }

--- a/duo-universal-sdk/src/main/java/com/duosecurity/model/Token.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/model/Token.java
@@ -19,8 +19,9 @@ public class Token implements Serializable {
   private List<String> amr;
 
   /**
-   * Constructor with all properties.
-   * 
+   * Constructor for the legacy set of claims. Does not set {@code amr};
+   * use {@link #setAmr(java.util.List)} for that.
+   *
    * @param iss iss
    * @param sub sub
    * @param preferredUsername preferred_username
@@ -152,6 +153,7 @@ public class Token implements Serializable {
           + ", getIss()=" + getIss()
           + ", getPreferred_username()=" + getPreferred_username()
           + ", getSub()=" + getSub()
+          + ", getAmr()=" + getAmr()
           + ", hashCode()=" + hashCode()
           + ", getClass()=" + getClass()
           + ", toString()=" + super.toString()

--- a/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
@@ -147,7 +147,11 @@ class UtilsTest {
     }
 
     @Test
-    void transformDecodedJwtToTokenWithNonStringAmrElements() {
+    void transformDecodedJwtToTokenWithNumericAmrElements() {
+        // Jackson coerces numeric elements to their string form when the target
+        // type is String, so this does not throw and yields ["1", "2"].
+        // The try/catch in extractAmr is defense-in-depth for genuinely
+        // non-coercible element types.
         String jwt = JWT.create()
             .withIssuer("issuer")
             .withSubject("test")
@@ -158,7 +162,7 @@ class UtilsTest {
 
         Token token = assertDoesNotThrow(() -> Utils.transformDecodedJwtToToken(decodedJWT));
 
-        assertNull(token.getAmr());
+        assertEquals(Arrays.asList("1", "2"), token.getAmr());
     }
 
     @Test

--- a/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
@@ -8,8 +8,11 @@ import com.duosecurity.model.*;
 import org.junit.jupiter.api.Test;
 
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -70,7 +73,7 @@ class UtilsTest {
 
     @Test
     void transformDecodedJwtToToken() {
-        String jwt = createTestJWT();    
+        String jwt = createTestJWT();
         // Just testing the transform logic so a simple decode is sufficient
         DecodedJWT decodedJWT =  JWT.decode(jwt);
         Token token = Utils.transformDecodedJwtToToken(decodedJWT);
@@ -78,6 +81,39 @@ class UtilsTest {
         assertEquals(token.getIss(), "issuer");
         assertEquals(token.getSub(), "test");
         assertEquals(token.getAud(), "aud");
+        // amr claim is optional; when absent, the field should be null.
+        assertNull(token.getAmr());
+    }
+
+    @Test
+    void transformDecodedJwtToTokenWithAmr() {
+        List<String> amr = Arrays.asList("mfa", "otp");
+        String jwt = JWT.create()
+            .withIssuer("issuer")
+            .withSubject("test")
+            .withAudience("aud")
+            .withArrayClaim("amr", amr.toArray(new String[0]))
+            .sign(Algorithm.HMAC512(CLIENT_SECRET));
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+
+        Token token = Utils.transformDecodedJwtToToken(decodedJWT);
+
+        assertEquals(amr, token.getAmr());
+    }
+
+    @Test
+    void transformDecodedJwtToTokenWithEmptyAmr() {
+        String jwt = JWT.create()
+            .withIssuer("issuer")
+            .withSubject("test")
+            .withAudience("aud")
+            .withArrayClaim("amr", new String[0])
+            .sign(Algorithm.HMAC512(CLIENT_SECRET));
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+
+        Token token = Utils.transformDecodedJwtToToken(decodedJWT);
+
+        assertEquals(Collections.emptyList(), token.getAmr());
     }
 
     @Test

--- a/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
@@ -117,6 +117,67 @@ class UtilsTest {
     }
 
     @Test
+    void transformDecodedJwtToTokenWithNullAmr() {
+        String jwt = JWT.create()
+            .withIssuer("issuer")
+            .withSubject("test")
+            .withAudience("aud")
+            .withNullClaim("amr")
+            .sign(Algorithm.HMAC512(CLIENT_SECRET));
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+
+        Token token = Utils.transformDecodedJwtToToken(decodedJWT);
+
+        assertNull(token.getAmr());
+    }
+
+    @Test
+    void transformDecodedJwtToTokenWithNonArrayAmr() {
+        String jwt = JWT.create()
+            .withIssuer("issuer")
+            .withSubject("test")
+            .withAudience("aud")
+            .withClaim("amr", "mfa")
+            .sign(Algorithm.HMAC512(CLIENT_SECRET));
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+
+        Token token = Utils.transformDecodedJwtToToken(decodedJWT);
+
+        assertNull(token.getAmr());
+    }
+
+    @Test
+    void transformDecodedJwtToTokenWithNonStringAmrElements() {
+        String jwt = JWT.create()
+            .withIssuer("issuer")
+            .withSubject("test")
+            .withAudience("aud")
+            .withArrayClaim("amr", new Integer[]{1, 2})
+            .sign(Algorithm.HMAC512(CLIENT_SECRET));
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+
+        Token token = assertDoesNotThrow(() -> Utils.transformDecodedJwtToToken(decodedJWT));
+
+        assertNull(token.getAmr());
+    }
+
+    @Test
+    void tokenEqualityRespectsAmrField() {
+        Token a = new Token();
+        a.setAmr(Arrays.asList("mfa"));
+        Token b = new Token();
+        b.setAmr(Arrays.asList("mfa"));
+        Token c = new Token();
+        c.setAmr(Arrays.asList("otp"));
+        Token d = new Token();
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a, d);
+    }
+
+    @Test
     void getAndValidateUrl() throws DuoException {
         URL result = Utils.getAndValidateUrl("my_host", "/file");
         assertEquals(result.getHost(), "my_host");


### PR DESCRIPTION
## Summary
- Add an optional `amr` field (`List<String>`) to the `Token` model to surface the Authentication Methods References claim added to the `/token` endpoint response ([Duo OAuth API docs](https://duo.com/docs/oauthapi#endpoints)).
- Populate the field in `Utils.transformDecodedJwtToToken()` via `decodedJwt.getClaim("amr").asList(String.class)`. The claim is optional, so absent claims leave the field `null` (java-jwt's `NullClaim.asList()` returns `null`) — the same pattern already used for other optional claims in this method.
- Update `equals`/`hashCode`/`toString` on `Token` accordingly. The existing all-args constructor is intentionally left unchanged to preserve the public API; callers use the no-arg constructor with setters.

## Note for reviewers
The `amr` claim has three possible states from Duo: absent, empty list, or a list of strings. This PR preserves that distinction — a missing claim leaves `getAmr()` returning `null`, and an empty list returns `Collections.emptyList()`. This is consistent with the other optional fields on `Token` (`auth_result`, `auth_context`, etc.), which also use `null` to signal "not provided." If reviewers would prefer collapsing absent → empty list so callers only need to handle one shape, happy to change it.

## Test plan
- [x] `transformDecodedJwtToToken` — asserts `getAmr()` is `null` when the claim is missing
- [x] `transformDecodedJwtToTokenWithAmr` — asserts a populated list round-trips
- [x] `transformDecodedJwtToTokenWithEmptyAmr` — asserts an empty list round-trips
- [ ] `mvn -pl duo-universal-sdk test` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)