### PR TITLE
Add CA bundle version and pinning status to user agent string

### DIFF
--- a/duo-universal-sdk/src/main/java/com/duosecurity/Client.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Client.java
@@ -40,6 +40,8 @@ public class Client {
 
   private static final String USER_AGENT_VERSION = "1.3.3-SNAPSHOT";
 
+  private static final String CA_BUNDLE_VERSION = "1.0";
+
   // **************************************************
   // Fields
   // **************************************************
@@ -373,7 +375,9 @@ public class Client {
       client.apiHost = apiHost;
       client.redirectUri = redirectUri;
       client.useDuoCodeAttribute = useDuoCodeAttribute;
-      client.userAgent = userAgent;
+      String caPinningStatus = caPinningDisabled ? "disabled" : "enabled";
+      client.userAgent = format("%s ca_bundle/%s (ca_pinning=%s)",
+              userAgent, CA_BUNDLE_VERSION, caPinningStatus);
       client.duoConnector = new DuoConnector(apiHost, proxyHost, proxyPort,
               caPinningDisabled ? null : caCerts);
 

--- a/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
@@ -233,7 +233,60 @@ class ClientTest {
         ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
         verify(client.duoConnector).exchangeAuthorizationCodeFor2FAResult(stringCaptor.capture(), anyString(), anyString(), anyString(), anyString(), anyString());
         String sentUserAgent = stringCaptor.getValue();
-        assertTrue(sentUserAgent.startsWith("duo_universal_java") && sentUserAgent.endsWith(appendedUserAgent));
+        assertTrue(sentUserAgent.startsWith("duo_universal_java") && sentUserAgent.contains(appendedUserAgent));
+    }
+
+    @Test
+    void userAgent_includes_ca_bundle_version() throws DuoException {
+        Client client = new Client.Builder(CLIENT_ID, CLIENT_SECRET, API_HOST, HTTPS_REDIRECT_URI).build();
+        client.duoConnector = Mockito.mock(DuoConnector.class);
+
+        try {
+            client.exchangeAuthorizationCodeFor2FAResult("duo_code", Mockito.mock(TokenValidator.class));
+        } catch (Exception e) {
+            // ignored
+        }
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client.duoConnector).exchangeAuthorizationCodeFor2FAResult(stringCaptor.capture(), anyString(), anyString(), anyString(), anyString(), anyString());
+        String sentUserAgent = stringCaptor.getValue();
+        assertTrue(sentUserAgent.contains("ca_bundle/1.0"));
+    }
+
+    @Test
+    void userAgent_includes_ca_pinning_enabled() throws DuoException {
+        Client client = new Client.Builder(CLIENT_ID, CLIENT_SECRET, API_HOST, HTTPS_REDIRECT_URI).build();
+        client.duoConnector = Mockito.mock(DuoConnector.class);
+
+        try {
+            client.exchangeAuthorizationCodeFor2FAResult("duo_code", Mockito.mock(TokenValidator.class));
+        } catch (Exception e) {
+            // ignored
+        }
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client.duoConnector).exchangeAuthorizationCodeFor2FAResult(stringCaptor.capture(), anyString(), anyString(), anyString(), anyString(), anyString());
+        String sentUserAgent = stringCaptor.getValue();
+        assertTrue(sentUserAgent.contains("(ca_pinning=enabled)"));
+    }
+
+    @Test
+    void userAgent_includes_ca_pinning_disabled() throws DuoException {
+        Client client = new Client.Builder(CLIENT_ID, CLIENT_SECRET, API_HOST, HTTPS_REDIRECT_URI)
+                .disableCaPinning()
+                .build();
+        client.duoConnector = Mockito.mock(DuoConnector.class);
+
+        try {
+            client.exchangeAuthorizationCodeFor2FAResult("duo_code", Mockito.mock(TokenValidator.class));
+        } catch (Exception e) {
+            // ignored
+        }
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client.duoConnector).exchangeAuthorizationCodeFor2FAResult(stringCaptor.capture(), anyString(), anyString(), anyString(), anyString(), anyString());
+        String sentUserAgent = stringCaptor.getValue();
+        assertTrue(sentUserAgent.contains("(ca_pinning=disabled)"));
     }
 
     @Test


### PR DESCRIPTION
## Description
- Added `CA_BUNDLE_VERSION = "1.0"` constant in `Client.java`
- Modified `Builder.build()` to append `ca_bundle/1.0` and `(ca_pinning=enabled|disabled)` to the user agent string based on the `caPinningDisabled` runtime state
- The pinning status is derived from the same `caPinningDisabled` flag that configures TLS, so the reported value always matches the client's actual pinning state

## How Has This Been Tested?
- `userAgent_includes_ca_bundle_version` — verifies `ca_bundle/1.0` is present in the user agent
- `userAgent_includes_ca_pinning_enabled` — verifies `(ca_pinning=enabled)` when pinning is not disabled
- `userAgent_includes_ca_pinning_disabled` — verifies `(ca_pinning=disabled)` when `disableCaPinning()` is called

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)