### PR TITLE
chore: update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,11 +30,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -59,4 +59,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -17,10 +17,10 @@ jobs:
         java-version: [8, 11, 17, 21]
 
      steps:
-       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
        - name: Set up Java
-         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
          with:
            distribution: 'temurin'
            java-version: ${{ matrix.java-version }}

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up JDK 11
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -25,13 +25,13 @@ jobs:
       uses: duosecurity/duo_client_python/.github/actions/sbom-convert@master
 
     - name: Archive SBOM artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: duo_universal_java_sbom
         path: spdx.json
 
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: '11'
         distribution: 'temurin'


### PR DESCRIPTION
## Summary
Updates GitHub Actions to Node 24-compatible versions ahead of the runner change: GitHub Actions runners default to Node 24 on **2026-06-16** and remove Node 20 in **fall 2026**. JS actions on Node 12/16/20 are all affected.

Every JS-based action is bumped to its latest Node 24-capable release, **SHA-pinned** with a version comment.

## Not changed (no Node 24 release / composite / archived)
- `darenm/Setup-VSTest` — no Node 24 release exists
- `dtolnay/rust-toolchain` — composite action, unaffected
- `actions/create-release`, `actions/upload-release-asset` — archived; need a rewrite

Only present where applicable in this repo.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

*This PR was generated with AI assistance (Claude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)