### PR TITLE
Add KEYS file with Maven signing public keys

### DIFF
--- a/KEYS
+++ b/KEYS
@@ -1,0 +1,115 @@
+This file contains the PGP keys used to sign duo_universal_java releases
+published to Maven Central. It contains public key material only.
+
+Users:
+    gpg --import KEYS
+    gpg --verify duo-universal-sdk-<version>.jar.asc duo-universal-sdk-<version>.jar
+
+Developers:
+    Append new signing keys. Never replace this file or delete a key that has
+    signed a release, so signatures on earlier releases remain verifiable.
+
+    gpg --armor --export <key id> >> KEYS
+
+    duo_client_java is signed with these same keys - keep its KEYS file in sync.
+
+---------------------------------------------------------------------------
+
+Duo Security Maven Signing Key (current)
+Fingerprint: 7ED4 A780 3AFC 6DE8 47DF  9A3F 70EE 73F2 1701 2D0E
+Created: 2026-03-20   Expires: 2029-03-19
+Signs: duo-universal-sdk 1.3.2 and later
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBGm9omcBEADMHBgnHZWEgo0M40t14zDSjaQ/F6f2NxOAxGTo6lEgNPYTlkRx
++MyK8Dzf2rkiioyeNLZ8SFpN4iH9Gdh8ah2L/YfDQPPUmu5h6vy6sxOX+MlfGZzl
+7djBFeT4qLUll3cRjahTYqaDzpyUpQ2YizhFWnAB7O8PJPueh1BtewNOjOio4OE2
+fwfY72JPQcaWwMT+eXGUBfLv2qIFJPymmYSM+D4qMVYC2a/iNWMvYNvqjDTFVhbn
+3zH2BOSYwG6LOdBKrsb3Ol6sUVGMEGUqqq2ly2icWQvAs2F15JPkstNp/qk7W7jM
++8Ed8vfufcEh/twPwefzzNmkLZVmmiBN0ImeyFHuuERIX+Pu3tdAuAl9LvRkf+Xr
+zWR6XKPadtzdUo2eH2atOOmmIpfdGhzFKPaklHJa56sAHXmhmk6YrHwyG4KaRDyh
+OnTaXSWqxchMlDwUzb4d29PqBm0l0xR6yVcVesX2uFW4rkYSYGqnJlY88PYCi2EU
+EdHI3ICejULExhb+P+oK1t6fR0WFVxo9ezFG06TDPhapSKX6FryTM/zifN+A6I1Y
+3Y3uj/mc4IYsf1nlwPbTnFp87TTGhOG3NcapHioO8Xxsg0D4JfD6KVYoTJZQUhV3
+NtPisT+FKPDBMHZODrNLjLUfMQWOV0F5817ZXRd8b0yhPq0wR6gObsAwRwARAQAB
+tDFEdW8gU2VjdXJpdHkgTWF2ZW4gU2lnbmluZyA8aW50ZWdyYXRpb25zQGR1by5j
+b20+iQJXBBMBCABBFiEEftSngDr8behH35o/cO5z8hcBLQ4FAmm9omcCGwMFCQWj
+moAFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQcO5z8hcBLQ7vYA/+OOKq
+XA0YY3D1C3TsxtMQ0l1SffVBJZv8O1W5vRqx1nDuCCsrFy6MWdMW+0/3cuS8td3b
+pjKiuvpUPVmFM3W8N9r3xVdR9b8BqHBT99OMI3D43qgXKjYbHsY3Qwuc2TZYYveV
+n9iXysi2hB70470Roa27lH52v4/zmLg+4m7CJxbTGTeQbSNDB+BWA7mmAvt1in3K
+Mx1svU8xPdGYnnmtClv4Q0IUXORlW1dsZIn+mTXaC5BDouPBskJjm+LQ8QZE+IQO
+1vH+HTuZNa6/OQfp/TLLEAkPmd3cl152P59yortHt+ZEQJz1ZqSevYpbSjl34P19
+BeX5hOKPF707vl4EVTPCgmYK8B0nJ6q9L+ESE5Jm/4CSwLXbEEIYVI8DzQyx+m3m
+wkKLN0toxFRbB8HD2nZo4lpsv3FESLjzQwL/jtK/fKaLhqoL9b+07vKAiAp8CBje
+zLsK2Tm/tZGWcEn5Z1eFCeTVsyBjJ177lQYJt2g5q3JLg5ntkeENIzO1x3c8uXF4
+Hehl9ytq0iXWqc2qH2NdWf9v9nKNhBSvibx8cOhuvBkT/eDCPPpv08ugQqphXdNV
+YpyF/GJ0djdj8s66rQ67DnQA/F7p9sJMvzoC/Wp6720iDcdMg7THKsaLcfeInNMv
+ovMZTpcapSUsjFNB7nOo7fNCuKIQLNXk6qFUQMQ=
+=tO2z
+-----END PGP PUBLIC KEY BLOCK-----
+
+---------------------------------------------------------------------------
+
+Duo Security Maven Signing Key (retired)
+Fingerprint: 20FF 0D66 B2D0 202C 1544  7339 7E77 F31E 27A4 AEA2
+Created: 2020-11-10   Expired: 2026-01-27
+Signs: duo-universal-sdk 1.0.2 through 1.3.1
+Retained so that signatures made while this key was valid remain verifiable.
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF+qv6UBEADMr0wAhf6oXcht0Y2l/DFFaaga+9UWoxQ/ARbxZZ1XZn8b6NYe
+3QZ6roGUCDfQ7FoaRbOKBbRV8uuiYlO60h6PUI72DjVikVeBXvFuZtA/eluHXSrf
+TENRgOcYtpYkvNI/564Ym/YhL+KovpImMd95iZs+lBscW4mL5fsQnHocQdYzQkxl
+r+g6KwkVrYGgWzMmN65tlVJ/SZUtRtOhVnGdTqiP7tkPr7BtM1A7+aZepuMuHceL
+r+h2l0ADFvl/2gZtmMzxqneu3SQRUZdQ3OK/sOBuLG4xCO0AYHgKfPBQqUd6ZVd/
+w9uLnczJawr2HUugQF8o05TB52fmJyIx0NNQDKYWEslV2eAGL4ZCywInCUqfcNY6
+DWccX9UE5+QNf09e3wrJ9bUEEuLY09daxXefF6y9iMLlzhqxunLyEX5grhF7TSLs
+gyP7xBVq7OrGndcAEaWB9xNxp7h36MNkU4vYjGFCHRooBrvU4rrTE9PrRYnRmtHy
+cjwNvJKYiuEJBObH7YsVkBMv6nPKUWOZqxjAmaNjUYNbKmc9f3XHTitWNVgpDyxC
+g1xkic34nERRgpNkceFOKhigGZ7Jy6u20XlkTrWRIpdUiNi+H4TyCsDK3KdVNJwi
+ZJGKfD3wNRdMuc/kyzMgR6g/7q6I2XZsKyHQrZy/g5Fsehaw1cAmcTEHowARAQAB
+tE9EdW8gU2VjdXJpdHkgTWF2ZW4gU2lnbmluZyAoRm9yIHNpZ25pbmcgTWF2ZW4g
+YXJ0aWZhY3RzKSA8aW50ZWdyYXRpb25zQGR1by5jb20+iQJWBBMBCABAAhsDBwsJ
+CAcDAgEGFQgCCQoLBBYCAwECHgECF4AWIQQg/w1mstAgLBVEczl+d/MeJ6SuogUC
+Z5fqqwUJCc5ehgAKCRB+d/MeJ6SuohS4D/9QN031uoseXrxGuv2//3nFVsviD/eb
+KOQVdMtSLqyDrImqdlKzqUNTWLTyDwsoX1F7GFylrPPMwvxXHw55yF2OaplDPceA
+0YBPvwRy5yzp3nS77VutKM0MCQT55MSXx2lZpcK7jPtnkBUnfKnZge0KNnT8N4Cc
+tjK2Oo8712PhB3xSQzCQld/Im7rIz5GGCr/DD7RQGirlH/6vKAGGpnP3N+ajdh/4
+dOPciBrCbi/yrOaGxUJJrVwKM9Q4+NuGBQjrB7ONkGCxW/2GhMXG7kNp9SLWx0Ct
+D+pBETuI6Y2gAPDyZog5axX0RGKxhq69GhZmh/a2VrotYx9a2RSIDjgpLWB1R37O
+aaR7xxN7idcAt8seTC3x4K6gw3DjzGeqReZpB4u3PsXin2xxAbyZsos7oxiRi7iX
+Zu8Bjf3wMXymDasBIPbpub0Bk04N8NLQIXR7pdAQkvTGbAOKsTol/WNLExsXcm6L
+vLEaeiKXawNCG58oZIcq+PSMFKVjTHCBAymSIJyD2ixilF326+NgI+h4LRd+/SeM
+QPtixqijbJpPet4V81LgjTpBiJn43h28haWQ8j1/rTCrjvKznZjVCHT+iD6OObx0
+ZhRQZPnZeLa4iBA6MD3M/rCofqZxP8QSpUhXfCQSP8SRDs7POCJ4SJSrIbK11Vf+
+qLdqrsghy2f+GYkCVgQTAQgAKQIbAwcLCQgHAwIBBhUIAgkKCwQWAgMBAh4BAheA
+BQJlqDAVBQkH3qPwACEJEH538x4npK6iFiEEIP8NZrLQICwVRHM5fnfzHiekrqL7
+Bw/9GmvEcZx3xlCb2RK8K70AKaqlH7Q+yZt5GWXqivo4EI9g3C6pUU8SQaivyZNO
+e+9r8hYpsFin5OW/1G2pPdePiyCVkrjurLgTThcvqD0jWDVfLgP+i3IDnLHBIKPO
+kItY0H1sV7UF76lGAm5zizBJksghZJeb+FmeqW0LAFjc/0DVLJC1sR+c5kQeh74m
+MZ+uo7g4tCIc1uQJWpwbinKfvz/e2S/pHRwNak6Tb7ypybG7i7M2jmwLg1pw0VFs
+WF7FJCzGkYaymOG2ioAPF0yfvYJbUPQ+1g58wvZ1jBLdXj/T154uMeFyQcoCdHbV
+ZYWi7LknPqWMfuglnru3wkihDTaIZUy6lMuwv7QcbWiDBflGZAEODHizcSZLdjLX
+0/qAnwTLfTK7pkymnA7NcFprtaAPhjqGkDyJx1AWOdWyyYWykMX5RPMnIZUwXB0V
+yP4nhVVhs2NlGsM8n67BZszUVja2aO/JjvG8vCmwehFfNwdY7HNFqEYgwLevegbR
+NbXbQlJlRvlUINNKcoStvTZ6bmcdGN0njXOal1iLPAdrSa/gEDHCzb8WLpz/5xJG
+j7G1kMrbH8W6bOSfdsuSVHATO1g5JX06uDXGEucZiY66oIs2jawO8rfvLuh1seTW
+5a17KFFQYjajg7mAaOpGk/9eKozi0PbS/bP0L9mIc+o57yqJAlYEEwEIACkFAl+q
+v6UCGwMFCQWjmoAHCwkIBwMCAQYVCAIJCgsEFgIDAQIeAQIXgAAhCRB+d/MeJ6Su
+ohYhBCD/DWay0CAsFURzOX538x4npK6i/vAP/AyI26i0aEyOJ+LFyIwvC8ouu1kB
+ZuFqVEK/7JnR/a/09ESJKmFsyUQs8izNE/nxMsinoqmjfSQ2nC/8CTntYEPz/XPI
+9zzWrnrZpB6oTi/zQr1PZHzYpm7ANq2spmf4kE1RbmhtKJqqabWr9kECVypQIRUf
+LqPXR23RVapwI5mckvgkFvwXJk7NNOFQvUF4MZ1jhLnFe4xxfoZVgeCydH2qZxv9
+EB5r0eKAXAZNfIzLyzj2xpdJlMWlBHdUm1l1NNLJsZNzFlfpYP16OGUfaNVFvEFc
+h38Kh/p0ldVBb73wOG8LXiWZB5IDzAmzgf9OfvdaLVJSzmcK6GAXs4/AEbFO990m
+NbYB1HZdCiYNx4jlSF/bdIN5WzF2NRapipv040Gnt4GCM1ZKc+J6WrX4OHsRyxcR
+6unlqJPaORpUctHpbb3A8Um7v0Z6WIVpCu71DhkG+oMCixZPrc+CALWIhNuc3A0G
+BMrAgvVjzoTmhDoDRRrlN8+7RNohQwm2ZjyBQxn1GgKGjpRaMMsPwlbqXUSuzBHM
+v71PbWymHi4J2aI9K1KpRj+wGO8bQjRC75MDCBm4NOcaH+gK12GCqmfK+5dOr1Xi
+5PAQXAzb0OCW/yLmguRRqo4YCfNhupLvcmm4M6ZHRnr5B6WNqP9o4GESXxourjAs
+6H5mF/ctKCc76pvK
+=O2Jb
+-----END PGP PUBLIC KEY BLOCK-----

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Issues](https://img.shields.io/github/issues/duosecurity/duo_universal_java)](https://github.com/duosecurity/duo_universal_java/issues)
 [![Forks](https://img.shields.io/github/forks/duosecurity/duo_universal_java)](https://github.com/duosecurity/duo_universal_java/network/members)
 [![Stars](https://img.shields.io/github/stars/duosecurity/duo_universal_java)](https://github.com/duosecurity/duo_universal_java/stargazers)
-[![License](https://img.shields.io/badge/License-View%20License-orange)](https://github.com/duosecurity/duo_universal_java/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/License-View%20License-orange)](https://github.com/duosecurity/duo_universal_java/blob/main/LICENSE)
 
 
 This library allows a web developer to quickly add Duo's interactive, self-service, two-factor authentication to any Java web login form.
@@ -34,6 +34,30 @@ See https://central.sonatype.com/artifact/com.duosecurity/duo-universal-sdk/1.3.
 ## TLS 1.2 and 1.3 Support
 
 Duo_universal_java uses the Java cryptography libraries for TLS operations. Both TLS 1.2 and 1.3 are supported by Java 8 and later versions.
+
+## Verifying releases
+
+Artifacts published to Maven Central are signed with one of Duo's Maven signing keys.
+The public keys are in [`KEYS`](KEYS) in this repository.
+
+```
+curl -O https://raw.githubusercontent.com/duosecurity/duo_universal_java/main/KEYS
+gpg --import KEYS
+gpg --verify duo-universal-sdk-1.3.2.jar.asc duo-universal-sdk-1.3.2.jar
+```
+
+The `.jar.asc` signature files are available alongside each artifact on Maven Central,
+for example <https://repo1.maven.org/maven2/com/duosecurity/duo-universal-sdk/1.3.2/>.
+
+| Versions | Key fingerprint |
+| --- | --- |
+| 1.3.2 and later | `7ED4 A780 3AFC 6DE8 47DF  9A3F 70EE 73F2 1701 2D0E` |
+| 1.0.2 through 1.3.1 | `20FF 0D66 B2D0 202C 1544  7339 7E77 F31E 27A4 AEA2` (expired 2026-01-27) |
+
+A `Good signature` result confirms the artifact was signed with a Duo key. GPG also
+reports the key as untrusted unless you have signed it yourself, and reports the
+retired key as expired; neither affects the validity of signatures made while that
+key was valid.
 
 # Demo
 


### PR DESCRIPTION
## Summary

Release artifacts on Maven Central are signed, and the public keys have been published
to public keyservers. #60 asks for a way to confirm that the key used to sign a release
is one this project intends — that is, a source for the keys tied to the project itself.
Raised after the signing key rotated between 1.3.1 and 1.3.2.

- Adds a `KEYS` file at the repo root with both signing keys.
- Adds a `## Verifying releases` section to the README with the verification commands
  and a version → fingerprint table.
- Fixes the LICENSE badge, which pointed at the old `master` branch.

| Key | Signs |
| --- | --- |
| `7ED4 A780 3AFC 6DE8 47DF  9A3F 70EE 73F2 1701 2D0E` | 1.3.2 and later |
| `20FF 0D66 B2D0 202C 1544  7339 7E77 F31E 27A4 AEA2` | 1.0.2 through 1.3.1 (expired 2026-01-27) |

The file contains public key material only. Trust derives from commit access: whoever
can change this file can change the code it signs.

The retired key is retained so signatures made while it was valid remain verifiable.
The file is append-only by design — deleting a key would break verification of
already-published releases.

## How Has This Been Tested?

- [x] `gpg --import KEYS` → 2 keys imported, 0 secret keys, no `PRIVATE KEY` markers
- [x] All **9** published `duo-universal-sdk` versions (1.0.2 → 1.3.2) verify against
      these two keys and no others. 1.0.2–1.3.1 report `Good signature ... [expired]`
      (`EXPKEYSIG` — key expired *after* the signature was made, which is expected);
      1.3.2 reports `Good signature` (`GOODSIG`).
- [x] Keys cross-checked against independent fetches from `keyserver.ubuntu.com` and
      `keys.openpgp.org` — identical fingerprints and identical canonical export.
- [x] Header dates and version ranges derived from the key packets and from the signing
      key IDs on the `.jar.asc` files, not hand-entered.
- [x] Fingerprint text matches `gpg --fingerprint` output character-for-character.
- [x] The README command sequence and the `Developers:` append command in `KEYS` both
      run verbatim.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Release management

Refs #60