### PR TITLE
Set outgoing JWT expiration to 5 minutes to match other SDKs

### DIFF
--- a/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 public class Utils {
 
-  private static final int ONE_HOUR_IN_MILLISECONDS = 3600000;
+  private static final int FIVE_MINUTES_IN_MILLISECONDS = 300000;
 
   private static final String HTTPS = "https";
 
@@ -34,7 +34,7 @@ public class Utils {
 
   static String createJwt(String clientId, String clientSecret, String aud) {
     Date expiration = new Date();
-    expiration.setTime(expiration.getTime() + ONE_HOUR_IN_MILLISECONDS);
+    expiration.setTime(expiration.getTime() + FIVE_MINUTES_IN_MILLISECONDS);
     return JWT.create()
               .withHeader(HEADERS)
               .withIssuer(clientId)
@@ -49,7 +49,7 @@ public class Utils {
                                     String state, String username,
                                     Boolean useDuoCodeAttribute) {
     Date expiration = new Date();
-    expiration.setTime(expiration.getTime() + ONE_HOUR_IN_MILLISECONDS);
+    expiration.setTime(expiration.getTime() + FIVE_MINUTES_IN_MILLISECONDS);
     return JWT.create()
               .withHeader(HEADERS)
               .withExpiresAt(expiration)


### PR DESCRIPTION
## Summary

The Java SDK signs its outgoing JWTs (the authorization-request JWT in `createJwtForAuthUrl` and the client-assertion JWT in `createJwt`) with a **1-hour** expiration. Every other Duo Universal Prompt SDK uses a **5-minute** expiration:

| SDK | Expiration | Source |
|-----|-----------|--------|
| **Java (before)** | **1 hour** | `Utils.java` `ONE_HOUR_IN_MILLISECONDS = 3600000` |
| C# | 5 min | `JwtUtils.cs` `AddMinutes(FIVE_MINUTES)` |
| Go | 5 min | `client.go` `const expirationTime = 300` |
| Node.js | 5 min | `constants.ts` `JWT_EXPIRATION = 300` |
| PHP | 5 min | `Client.php` `JWT_EXPIRATION = 300` |
| Python | 5 min (default; capped at 5 min) | `client.py` `FIVE_MINUTES_IN_SECONDS` |

This change brings Java in line with the rest of the SDK family by changing the expiration from `3600000` ms (1 hour) to `300000` ms (5 minutes), shrinking the validity window of these short-lived tokens by 12x.

## Changes

- Rename `ONE_HOUR_IN_MILLISECONDS` → `FIVE_MINUTES_IN_MILLISECONDS` and set it to `300000`. Applies to both `createJwt` and `createJwtForAuthUrl`.

## Testing

- `mvn test` — all 53 tests pass.
- `mvn checkstyle:check` — 0 violations.

No existing test asserts on the outgoing JWT's `exp` value, so no test changes were needed.

*This PR description was generated with AI assistance (Claude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)