### PR TITLE
Add dest_app_name, dest_app_id, display_username, max_age and prompt

### DIFF
--- a/duo-example/src/main/java/com/duosecurity/controller/LoginController.java
+++ b/duo-example/src/main/java/com/duosecurity/controller/LoginController.java
@@ -139,7 +139,7 @@ public class LoginController {
                     // Reauthenticate interactively if the remembered session is older than this
                     .setMaxAge(3600)
                     // Or force interactive reauthentication regardless of remembered session
-                    .setPrompt(AuthUrlOptions.PROMPT_LOGIN)
+                    .setPrompt(AuthUrlOptions.Prompt.LOGIN)
                     .build());
     */
     ModelAndView model = new ModelAndView("/redirect");

--- a/duo-example/src/main/java/com/duosecurity/controller/LoginController.java
+++ b/duo-example/src/main/java/com/duosecurity/controller/LoginController.java
@@ -126,7 +126,7 @@ public class LoginController {
                     .setNonce(nonce)
                     .build());
 
-    /* Example of setting the optional destination application and display fields
+    /* Example of setting the optional destination application, display and freshness fields
     String authUrl = duoClient.createAuthUrl(
             new AuthUrlOptions.Builder(username, state)
                     .setNonce(nonce)
@@ -136,6 +136,10 @@ public class LoginController {
                     .setDestAppId("vpn-prod-1")
                     // Shown in Duo Mobile's "user" field for Push, in place of the Duo username
                     .setDisplayUsername("a.smith@acme.com")
+                    // Reauthenticate interactively if the remembered session is older than this
+                    .setMaxAge(3600)
+                    // Or force interactive reauthentication regardless of remembered session
+                    .setPrompt(AuthUrlOptions.PROMPT_LOGIN)
                     .build());
     */
     ModelAndView model = new ModelAndView("/redirect");

--- a/duo-example/src/main/java/com/duosecurity/controller/LoginController.java
+++ b/duo-example/src/main/java/com/duosecurity/controller/LoginController.java
@@ -1,6 +1,7 @@
 package com.duosecurity.controller;
 
 
+import com.duosecurity.AuthUrlOptions;
 import com.duosecurity.Client;
 import com.duosecurity.exception.DuoException;
 import com.duosecurity.model.Token;
@@ -120,7 +121,23 @@ public class LoginController {
     stateMap.put(state, new Session(username, nonce));
 
     // Step 4: Create the authUrl and redirect to it
-    String authUrl = duoClient.createAuthUrl(username, state, nonce);
+    String authUrl = duoClient.createAuthUrl(
+            new AuthUrlOptions.Builder(username, state)
+                    .setNonce(nonce)
+                    .build());
+
+    /* Example of setting the optional destination application and display fields
+    String authUrl = duoClient.createAuthUrl(
+            new AuthUrlOptions.Builder(username, state)
+                    .setNonce(nonce)
+                    // Shown in Duo Mobile and recorded in the authentication log
+                    .setDestAppName("Acme VPN")
+                    // A long-lived identifier for that application; not shown to users
+                    .setDestAppId("vpn-prod-1")
+                    // Shown in Duo Mobile's "user" field for Push, in place of the Duo username
+                    .setDisplayUsername("a.smith@acme.com")
+                    .build());
+    */
     ModelAndView model = new ModelAndView("/redirect");
     model.addObject("authURL", authUrl);
     return model;

--- a/duo-universal-sdk/src/main/java/com/duosecurity/AuthUrlOptions.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/AuthUrlOptions.java
@@ -9,9 +9,29 @@ package com.duosecurity;
 public class AuthUrlOptions {
 
   /**
-   * The only value Duo currently accepts for {@link Builder#setPrompt(String)}.
+   * The values Duo accepts for {@link Builder#setPrompt(Prompt)}.
    */
-  public static final String PROMPT_LOGIN = "login";
+  public enum Prompt {
+    /**
+     * Force the user to authenticate interactively even when a remembered session exists.
+     */
+    LOGIN("login");
+
+    private final String value;
+
+    Prompt(String value) {
+      this.value = value;
+    }
+
+    /**
+     * The value Duo expects on the wire, which is not the name of the constant.
+     *
+     * @return the prompt value sent to Duo
+     */
+    public String getValue() {
+      return value;
+    }
+  }
 
   private final String username;
   private final String state;
@@ -20,7 +40,7 @@ public class AuthUrlOptions {
   private final String destAppId;
   private final String displayUsername;
   private final Integer maxAge;
-  private final String prompt;
+  private final Prompt prompt;
 
   private AuthUrlOptions(Builder builder) {
     this.username = builder.username;
@@ -61,7 +81,7 @@ public class AuthUrlOptions {
     return maxAge;
   }
 
-  public String getPrompt() {
+  public Prompt getPrompt() {
     return prompt;
   }
 
@@ -76,7 +96,7 @@ public class AuthUrlOptions {
     private String destAppId;
     private String displayUsername;
     private Integer maxAge;
-    private String prompt;
+    private Prompt prompt;
 
     /**
      * Builder.
@@ -161,16 +181,15 @@ public class AuthUrlOptions {
     }
 
     /**
-     * Optionally set the OIDC {@code prompt} value. Pass {@link AuthUrlOptions#PROMPT_LOGIN} to
-     * force the user to authenticate interactively even when a remembered session exists, which
-     * is equivalent to {@link #setMaxAge(Integer)} with {@code 0}. Duo does not currently accept
-     * any other value.
+     * Optionally set the OIDC {@code prompt} value. {@link Prompt#LOGIN} forces the user to
+     * authenticate interactively even when a remembered session exists, which is equivalent to
+     * {@link #setMaxAge(Integer)} with {@code 0}. It is the only value Duo currently accepts.
      *
      * @param prompt The prompt value to send
      *
      * @return the Builder
      */
-    public Builder setPrompt(String prompt) {
+    public Builder setPrompt(Prompt prompt) {
       this.prompt = prompt;
       return this;
     }

--- a/duo-universal-sdk/src/main/java/com/duosecurity/AuthUrlOptions.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/AuthUrlOptions.java
@@ -8,12 +8,19 @@ package com.duosecurity;
  */
 public class AuthUrlOptions {
 
+  /**
+   * The only value Duo currently accepts for {@link Builder#setPrompt(String)}.
+   */
+  public static final String PROMPT_LOGIN = "login";
+
   private final String username;
   private final String state;
   private final String nonce;
   private final String destAppName;
   private final String destAppId;
   private final String displayUsername;
+  private final Integer maxAge;
+  private final String prompt;
 
   private AuthUrlOptions(Builder builder) {
     this.username = builder.username;
@@ -22,6 +29,8 @@ public class AuthUrlOptions {
     this.destAppName = builder.destAppName;
     this.destAppId = builder.destAppId;
     this.displayUsername = builder.displayUsername;
+    this.maxAge = builder.maxAge;
+    this.prompt = builder.prompt;
   }
 
   public String getUsername() {
@@ -48,6 +57,14 @@ public class AuthUrlOptions {
     return displayUsername;
   }
 
+  public Integer getMaxAge() {
+    return maxAge;
+  }
+
+  public String getPrompt() {
+    return prompt;
+  }
+
   /**
    * Builds an {@link AuthUrlOptions}.
    */
@@ -58,6 +75,8 @@ public class AuthUrlOptions {
     private String destAppName;
     private String destAppId;
     private String displayUsername;
+    private Integer maxAge;
+    private String prompt;
 
     /**
      * Builder.
@@ -124,6 +143,35 @@ public class AuthUrlOptions {
      */
     public Builder setDisplayUsername(String displayUsername) {
       this.displayUsername = displayUsername;
+      return this;
+    }
+
+    /**
+     * Optionally limit how long ago the user's last interactive Duo authentication may have been.
+     * Duo forces the user to authenticate interactively again when a remembered session is older
+     * than this, and a value of {@code 0} always forces it.
+     *
+     * @param maxAge The number of seconds since the user last authenticated interactively
+     *
+     * @return the Builder
+     */
+    public Builder setMaxAge(Integer maxAge) {
+      this.maxAge = maxAge;
+      return this;
+    }
+
+    /**
+     * Optionally set the OIDC {@code prompt} value. Pass {@link AuthUrlOptions#PROMPT_LOGIN} to
+     * force the user to authenticate interactively even when a remembered session exists, which
+     * is equivalent to {@link #setMaxAge(Integer)} with {@code 0}. Duo does not currently accept
+     * any other value.
+     *
+     * @param prompt The prompt value to send
+     *
+     * @return the Builder
+     */
+    public Builder setPrompt(String prompt) {
+      this.prompt = prompt;
       return this;
     }
 

--- a/duo-universal-sdk/src/main/java/com/duosecurity/AuthUrlOptions.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/AuthUrlOptions.java
@@ -1,0 +1,139 @@
+package com.duosecurity;
+
+/**
+ * The set of values that describe a single authorization request.
+ *
+ * <p>Instances are created with {@link AuthUrlOptions.Builder} and passed to
+ * {@link Client#createAuthUrl(AuthUrlOptions)}.
+ */
+public class AuthUrlOptions {
+
+  private final String username;
+  private final String state;
+  private final String nonce;
+  private final String destAppName;
+  private final String destAppId;
+  private final String displayUsername;
+
+  private AuthUrlOptions(Builder builder) {
+    this.username = builder.username;
+    this.state = builder.state;
+    this.nonce = builder.nonce;
+    this.destAppName = builder.destAppName;
+    this.destAppId = builder.destAppId;
+    this.displayUsername = builder.displayUsername;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public String getNonce() {
+    return nonce;
+  }
+
+  public String getDestAppName() {
+    return destAppName;
+  }
+
+  public String getDestAppId() {
+    return destAppId;
+  }
+
+  public String getDisplayUsername() {
+    return displayUsername;
+  }
+
+  /**
+   * Builds an {@link AuthUrlOptions}.
+   */
+  public static class Builder {
+    private final String username;
+    private final String state;
+    private String nonce;
+    private String destAppName;
+    private String destAppId;
+    private String displayUsername;
+
+    /**
+     * Builder.
+     *
+     * @param username The user to be authenticated by Duo.
+     * @param state A randomly generated String of 16 to 1024 characters. This value will be
+     *              returned to the integration post 2FA and should be validated.
+     *              {@link Client#generateState} exists as a utility function to generate it.
+     */
+    public Builder(String username, String state) {
+      this.username = username;
+      this.state = state;
+    }
+
+    /**
+     * Optionally bind the resulting ID token to this authorization request with a nonce.
+     * The same value must be passed to
+     * {@link Client#exchangeAuthorizationCodeFor2FAResult(String, String, String)}, which will
+     * reject an ID token that does not carry it.
+     *
+     * @param nonce A randomly generated String of 16 to 1024 characters
+     *
+     * @return the Builder
+     */
+    public Builder setNonce(String nonce) {
+      this.nonce = nonce;
+      return this;
+    }
+
+    /**
+     * Optionally set the user-facing name of the application the user is authenticating to.
+     * Duo shows this name in Duo Mobile and records it in the authentication log.
+     *
+     * @param destAppName The name of the destination application
+     *
+     * @return the Builder
+     */
+    public Builder setDestAppName(String destAppName) {
+      this.destAppName = destAppName;
+      return this;
+    }
+
+    /**
+     * Optionally set a long-lived unique identifier for the destination application.
+     * This value is not shown to users.
+     *
+     * @param destAppId The identifier of the destination application
+     *
+     * @return the Builder
+     */
+    public Builder setDestAppId(String destAppId) {
+      this.destAppId = destAppId;
+      return this;
+    }
+
+    /**
+     * Optionally set the username shown in the Duo Mobile "user" field for Duo Push.
+     * Duo shows the authenticating username when this is not set. This does not change which
+     * user Duo authenticates.
+     *
+     * @param displayUsername The username to display to the user
+     *
+     * @return the Builder
+     */
+    public Builder setDisplayUsername(String displayUsername) {
+      this.displayUsername = displayUsername;
+      return this;
+    }
+
+    /**
+     * Build the options object.
+     *
+     * @return {@link AuthUrlOptions}
+     */
+    public AuthUrlOptions build() {
+      return new AuthUrlOptions(this);
+    }
+  }
+}

--- a/duo-universal-sdk/src/main/java/com/duosecurity/Client.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Client.java
@@ -508,22 +508,53 @@ public class Client {
    * @return String
    *
    * @throws DuoException For problems creating the auth url
+   *
+   * @see #createAuthUrl(AuthUrlOptions) to additionally send dest_app_name, dest_app_id or
+   *      display_username
    */
   public String createAuthUrl(String username, String state, String nonce) throws DuoException {
-    validateUsername(username);
-    validateState(state);
-    validateNonce(nonce);
+    return createAuthUrl(new AuthUrlOptions.Builder(username, state).setNonce(nonce).build());
+  }
+
+
+  /**
+   * Constructs a string which can be used to redirect the client browser to Duo for 2FA.
+   *
+   * <p>This is the full form of {@code createAuthUrl}, and the only one that can send the
+   * optional {@code dest_app_name}, {@code dest_app_id} and {@code display_username} values.
+   * For example:
+   *
+   * <pre>
+   * client.createAuthUrl(new AuthUrlOptions.Builder(username, state)
+   *         .setNonce(nonce)
+   *         .setDestAppName("Acme VPN")
+   *         .build());
+   * </pre>
+   *
+   * @param options The values describing this authorization request, built with
+   *                {@link AuthUrlOptions.Builder}.
+   *
+   * @return String
+   *
+   * @throws DuoException For problems creating the auth url, or if options is null
+   */
+  public String createAuthUrl(AuthUrlOptions options) throws DuoException {
+    if (options == null) {
+      throw new DuoException("Missing options");
+    }
+    validateUsername(options.getUsername());
+    validateState(options.getState());
+    validateNonce(options.getNonce());
     String request = createJwtForAuthUrl(clientId, clientSecret, redirectUri,
-            state, username, useDuoCodeAttribute, apiHost);
+            useDuoCodeAttribute, apiHost, options);
     String query = format(
             "?scope=openid&response_type=code&redirect_uri=%s&client_id=%s&request=%s",
             redirectUri, clientId, request);
-    if (nonce != null) {
-      query = format("%s&nonce=%s", query, urlEncode(nonce));
+    if (options.getNonce() != null) {
+      query = format("%s&nonce=%s", query, urlEncode(options.getNonce()));
     }
     return getAndValidateUrl(apiHost, OAUTH_V_1_AUTHORIZE_ENDPOINT + query).toString();
   }
-
 
   /**
    * Verifies the duoCode returned by Duo and exchanges it for a {@link Token} which contains

--- a/duo-universal-sdk/src/main/java/com/duosecurity/Client.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Client.java
@@ -509,8 +509,8 @@ public class Client {
    *
    * @throws DuoException For problems creating the auth url
    *
-   * @see #createAuthUrl(AuthUrlOptions) to additionally send dest_app_name, dest_app_id or
-   *      display_username
+   * @see #createAuthUrl(AuthUrlOptions) to additionally send dest_app_name, dest_app_id,
+   *      display_username, max_age or prompt
    */
   public String createAuthUrl(String username, String state, String nonce) throws DuoException {
     return createAuthUrl(new AuthUrlOptions.Builder(username, state).setNonce(nonce).build());
@@ -521,8 +521,8 @@ public class Client {
    * Constructs a string which can be used to redirect the client browser to Duo for 2FA.
    *
    * <p>This is the full form of {@code createAuthUrl}, and the only one that can send the
-   * optional {@code dest_app_name}, {@code dest_app_id} and {@code display_username} values.
-   * For example:
+   * optional {@code dest_app_name}, {@code dest_app_id}, {@code display_username},
+   * {@code max_age} and {@code prompt} values. For example:
    *
    * <pre>
    * client.createAuthUrl(new AuthUrlOptions.Builder(username, state)

--- a/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
@@ -68,10 +68,19 @@ public class Utils {
     addClaimIfPresent(jwt, "dest_app_name", options.getDestAppName());
     addClaimIfPresent(jwt, "dest_app_id", options.getDestAppId());
     addClaimIfPresent(jwt, "display_username", options.getDisplayUsername());
+    addClaimIfPresent(jwt, "max_age", options.getMaxAge());
+    addClaimIfPresent(jwt, "prompt", options.getPrompt());
     return jwt.sign(Algorithm.HMAC512(clientSecret));
   }
 
   private static void addClaimIfPresent(Builder jwt, String name, String value) {
+    if (value != null) {
+      jwt.withClaim(name, value);
+    }
+  }
+
+  private static void addClaimIfPresent(Builder jwt, String name, Integer value) {
+    // Only null counts as unset here; zero is a value Duo acts on.
     if (value != null) {
       jwt.withClaim(name, value);
     }

--- a/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
@@ -221,6 +221,9 @@ public class Utils {
       application.setName(applicationMap.containsKey("name")
                           && applicationMap.get("name") != null
                           ? applicationMap.get("name").toString() : null);
+      application.setDestination_name(applicationMap.containsKey("destination_name")
+                          && applicationMap.get("destination_name") != null
+                          ? applicationMap.get("destination_name").toString() : null);
     }
     return application;
   }

--- a/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
@@ -86,6 +86,12 @@ public class Utils {
     }
   }
 
+  private static void addClaimIfPresent(Builder jwt, String name, AuthUrlOptions.Prompt value) {
+    if (value != null) {
+      jwt.withClaim(name, value.getValue());
+    }
+  }
+
   static Token transformDecodedJwtToToken(DecodedJWT decodedJwt) {
     Token token = new Token();
     token.setIat(decodedJwt.getClaim("iat").asDouble());

--- a/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/Utils.java
@@ -3,6 +3,7 @@ package com.duosecurity;
 import static java.lang.String.format;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator.Builder;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Claim;
@@ -46,11 +47,11 @@ public class Utils {
   }
 
   static String createJwtForAuthUrl(String clientId, String clientSecret, String redirectUri,
-                                    String state, String username,
-                                    Boolean useDuoCodeAttribute, String apiHost) {
+                                    Boolean useDuoCodeAttribute, String apiHost,
+                                    AuthUrlOptions options) {
     Date expiration = new Date();
     expiration.setTime(expiration.getTime() + FIVE_MINUTES_IN_MILLISECONDS);
-    return JWT.create()
+    Builder jwt = JWT.create()
               .withHeader(HEADERS)
               .withExpiresAt(expiration)
               .withIssuer(clientId)
@@ -58,11 +59,22 @@ public class Utils {
               .withClaim("scope", "openid")
               .withClaim("client_id", clientId)
               .withClaim("redirect_uri", redirectUri)
-              .withClaim("state", state)
-              .withClaim("duo_uname", username)
+              .withClaim("state", options.getState())
+              .withClaim("duo_uname", options.getUsername())
               .withClaim("response_type", "code")
-              .withClaim("use_duo_code_attribute", useDuoCodeAttribute)
-              .sign(Algorithm.HMAC512(clientSecret));
+              .withClaim("use_duo_code_attribute", useDuoCodeAttribute);
+    // The remaining claims are optional, and Duo treats an absent claim differently from an
+    // empty one, so only add them when the caller supplied a value.
+    addClaimIfPresent(jwt, "dest_app_name", options.getDestAppName());
+    addClaimIfPresent(jwt, "dest_app_id", options.getDestAppId());
+    addClaimIfPresent(jwt, "display_username", options.getDisplayUsername());
+    return jwt.sign(Algorithm.HMAC512(clientSecret));
+  }
+
+  private static void addClaimIfPresent(Builder jwt, String name, String value) {
+    if (value != null) {
+      jwt.withClaim(name, value);
+    }
   }
 
   static Token transformDecodedJwtToToken(DecodedJWT decodedJwt) {

--- a/duo-universal-sdk/src/main/java/com/duosecurity/model/Application.java
+++ b/duo-universal-sdk/src/main/java/com/duosecurity/model/Application.java
@@ -8,10 +8,12 @@ public class Application implements Serializable {
 
   private String key;
   private String name;
+  private String destination_name;
 
   /**
-   * Constructor with all properties.
-   * 
+   * Constructor for the legacy set of properties. Does not set {@code destination_name};
+   * use {@link #setDestination_name(String)} for that.
+   *
    * @param key key
    * @param name  name
    */
@@ -43,12 +45,22 @@ public class Application implements Serializable {
     this.name = name;
   }
 
+  public String getDestination_name() {
+    return destination_name;
+  }
+
+  public void setDestination_name(String destinationName) {
+    this.destination_name = destinationName;
+  }
+
   @Override
   public String toString() {
     return "Application [key=" + key
         + ", name=" + name
+        + ", destination_name=" + destination_name
         + ", getKey()=" + getKey()
         + ", getName()=" + getName()
+        + ", getDestination_name()=" + getDestination_name()
         + ", hashCode()=" + hashCode()
         + ", getClass()=" + getClass()
         + ", toString()=" + super.toString()
@@ -65,7 +77,8 @@ public class Application implements Serializable {
     }
     Application other = (Application) obj;
     return Objects.equals(key, other.key)
-        && Objects.equals(name, other.name);
+        && Objects.equals(name, other.name)
+        && Objects.equals(destination_name, other.destination_name);
   }
 
   @Override
@@ -74,6 +87,7 @@ public class Application implements Serializable {
     int result = 1;
     result = prime * result + ((key == null) ? 0 : key.hashCode());
     result = prime * result + ((name == null) ? 0 : name.hashCode());
+    result = prime * result + ((destination_name == null) ? 0 : destination_name.hashCode());
     return result;
   }
 }

--- a/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
@@ -153,6 +153,69 @@ class ClientTest {
     }
 
     @Test
+    void createAuthUrl_with_options_sends_username_and_state() throws DuoException {
+        String urlString = client.createAuthUrl(new AuthUrlOptions.Builder(USERNAME, STATE).build());
+
+        DecodedJWT jwt = decodeRequestJwt(urlString);
+        assertEquals(USERNAME, jwt.getClaim("duo_uname").asString());
+        assertEquals(STATE, jwt.getClaim("state").asString());
+    }
+
+    @Test
+    void createAuthUrl_sends_dest_app_name() throws DuoException {
+        String urlString = client.createAuthUrl(
+                new AuthUrlOptions.Builder(USERNAME, STATE).setDestAppName("Acme VPN").build());
+
+        assertEquals("Acme VPN", decodeRequestJwt(urlString).getClaim("dest_app_name").asString());
+    }
+
+    @Test
+    void createAuthUrl_sends_dest_app_id() throws DuoException {
+        String urlString = client.createAuthUrl(
+                new AuthUrlOptions.Builder(USERNAME, STATE).setDestAppId("vpn-prod-1").build());
+
+        assertEquals("vpn-prod-1", decodeRequestJwt(urlString).getClaim("dest_app_id").asString());
+    }
+
+    @Test
+    void createAuthUrl_sends_display_username() throws DuoException {
+        String urlString = client.createAuthUrl(new AuthUrlOptions.Builder(USERNAME, STATE)
+                .setDisplayUsername("a.smith@acme.com").build());
+
+        DecodedJWT jwt = decodeRequestJwt(urlString);
+        assertEquals("a.smith@acme.com", jwt.getClaim("display_username").asString());
+        // display_username only changes what Duo shows the user; the username Duo authenticates
+        // and later returns as preferred_username must be unaffected.
+        assertEquals(USERNAME, jwt.getClaim("duo_uname").asString());
+    }
+
+    @Test
+    void createAuthUrl_omits_optional_claims_that_were_not_set() throws DuoException {
+        String urlString = client.createAuthUrl(new AuthUrlOptions.Builder(USERNAME, STATE).build());
+
+        DecodedJWT jwt = decodeRequestJwt(urlString);
+        // Duo treats an absent claim differently from one present with a null value, so an
+        // unset option must leave the claim out of the JWT entirely.
+        assertTrue(jwt.getClaim("dest_app_name").isMissing());
+        assertTrue(jwt.getClaim("dest_app_id").isMissing());
+        assertTrue(jwt.getClaim("display_username").isMissing());
+    }
+
+    @Test
+    void createAuthUrl_throws_exception_for_null_options() {
+        try {
+            client.createAuthUrl((AuthUrlOptions) null);
+            Assertions.fail();
+        } catch (DuoException e) {
+            assertEquals("Missing options", e.getMessage());
+        }
+    }
+
+    private static DecodedJWT decodeRequestJwt(String urlString) {
+        return JWT.decode(HttpUrl.parse(urlString).queryParameter("request"));
+    }
+
+    @Test
     void createAuthUrl_throws_exception_for_invalid_username() {
         try {
             client.createAuthUrl("", STATE);

--- a/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
@@ -190,6 +190,32 @@ class ClientTest {
     }
 
     @Test
+    void createAuthUrl_sends_max_age() throws DuoException {
+        String urlString = client.createAuthUrl(
+                new AuthUrlOptions.Builder(USERNAME, STATE).setMaxAge(300).build());
+
+        assertEquals(300, decodeRequestJwt(urlString).getClaim("max_age").asInt());
+    }
+
+    @Test
+    void createAuthUrl_sends_max_age_of_zero() throws DuoException {
+        String urlString = client.createAuthUrl(
+                new AuthUrlOptions.Builder(USERNAME, STATE).setMaxAge(0).build());
+
+        // Zero is a meaningful value to Duo -- it forces interactive reauthentication -- so it
+        // must be sent rather than treated as "unset".
+        assertEquals(0, decodeRequestJwt(urlString).getClaim("max_age").asInt());
+    }
+
+    @Test
+    void createAuthUrl_sends_prompt() throws DuoException {
+        String urlString = client.createAuthUrl(new AuthUrlOptions.Builder(USERNAME, STATE)
+                .setPrompt(AuthUrlOptions.PROMPT_LOGIN).build());
+
+        assertEquals("login", decodeRequestJwt(urlString).getClaim("prompt").asString());
+    }
+
+    @Test
     void createAuthUrl_omits_optional_claims_that_were_not_set() throws DuoException {
         String urlString = client.createAuthUrl(new AuthUrlOptions.Builder(USERNAME, STATE).build());
 
@@ -199,6 +225,8 @@ class ClientTest {
         assertTrue(jwt.getClaim("dest_app_name").isMissing());
         assertTrue(jwt.getClaim("dest_app_id").isMissing());
         assertTrue(jwt.getClaim("display_username").isMissing());
+        assertTrue(jwt.getClaim("max_age").isMissing());
+        assertTrue(jwt.getClaim("prompt").isMissing());
     }
 
     @Test

--- a/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/ClientTest.java
@@ -210,8 +210,9 @@ class ClientTest {
     @Test
     void createAuthUrl_sends_prompt() throws DuoException {
         String urlString = client.createAuthUrl(new AuthUrlOptions.Builder(USERNAME, STATE)
-                .setPrompt(AuthUrlOptions.PROMPT_LOGIN).build());
+                .setPrompt(AuthUrlOptions.Prompt.LOGIN).build());
 
+        // Duo expects the wire value, not the enum constant name.
         assertEquals("login", decodeRequestJwt(urlString).getClaim("prompt").asString());
     }
 

--- a/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
@@ -84,6 +84,45 @@ class UtilsTest {
     }
 
     @Test
+    void transformDecodedJwtToTokenWithApplicationDestinationName() {
+        // Duo echoes the dest_app_name sent on the authorize request back as
+        // auth_context.application.destination_name.
+        Map<String, Object> application = new HashMap<>();
+        application.put("key", "DIXXXXXXXXXXXXXXXXXX");
+        application.put("name", "Acme Corp");
+        application.put("destination_name", "Acme Intranet");
+        Map<String, Object> authContext = new HashMap<>();
+        authContext.put("application", application);
+
+        String jwt = JWT.create()
+            .withIssuer("issuer")
+            .withClaim("auth_context", authContext)
+            .sign(Algorithm.HMAC512(CLIENT_SECRET));
+        Token token = Utils.transformDecodedJwtToToken(JWT.decode(jwt));
+
+        Application result = token.getAuth_context().getApplication();
+        assertEquals("Acme Intranet", result.getDestination_name());
+        assertEquals("Acme Corp", result.getName());
+        assertEquals("DIXXXXXXXXXXXXXXXXXX", result.getKey());
+    }
+
+    @Test
+    void transformDecodedJwtToTokenWithoutApplicationDestinationName() {
+        Map<String, Object> application = new HashMap<>();
+        application.put("name", "Acme Corp");
+        Map<String, Object> authContext = new HashMap<>();
+        authContext.put("application", application);
+
+        String jwt = JWT.create()
+            .withIssuer("issuer")
+            .withClaim("auth_context", authContext)
+            .sign(Algorithm.HMAC512(CLIENT_SECRET));
+        Token token = Utils.transformDecodedJwtToToken(JWT.decode(jwt));
+
+        assertNull(token.getAuth_context().getApplication().getDestination_name());
+    }
+
+    @Test
     void transformDecodedJwtToToken() {
         String jwt = createTestJWT();
         // Just testing the transform logic so a simple decode is sufficient

--- a/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/UtilsTest.java
@@ -62,7 +62,8 @@ class UtilsTest {
 
     @Test
     void createJWTForAuthURL() throws DuoException {
-        String jwt = Utils.createJwtForAuthUrl("my_client_id", CLIENT_SECRET, "my_redirect_uri", "my_state", "my_username", true, "api-host.com");
+        String jwt = Utils.createJwtForAuthUrl("my_client_id", CLIENT_SECRET, "my_redirect_uri", true, "api-host.com",
+                new AuthUrlOptions.Builder("my_username", "my_state").build());
         // Just testing the transform logic so a simple decode is sufficient
         DecodedJWT decodedJWT = JWT.decode(jwt);
         assertEquals(decodedJWT.getClaim("client_id").asString(), "my_client_id");
@@ -73,7 +74,8 @@ class UtilsTest {
 
     @Test
     void createJWTForAuthURL_includes_iss_and_aud() throws DuoException {
-        String jwt = Utils.createJwtForAuthUrl("my_client_id", CLIENT_SECRET, "my_redirect_uri", "my_state", "my_username", true, "api-host.com");
+        String jwt = Utils.createJwtForAuthUrl("my_client_id", CLIENT_SECRET, "my_redirect_uri", true, "api-host.com",
+                new AuthUrlOptions.Builder("my_username", "my_state").build());
         DecodedJWT decodedJWT = JWT.decode(jwt);
         // Both are optional per Duo's OIDC docs, but every other Duo SDK sends them:
         // iss must equal the client_id and aud must equal https://{api_host}.

--- a/duo-universal-sdk/src/test/java/com/duosecurity/model/ApplicationTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/model/ApplicationTest.java
@@ -1,0 +1,40 @@
+package com.duosecurity.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApplicationTest {
+
+    @Test
+    void applications_with_different_destination_names_are_not_equal() {
+        Application application = new Application("key", "name");
+        application.setDestination_name("Acme Intranet");
+        Application other = new Application("key", "name");
+        other.setDestination_name("Acme Payroll");
+
+        assertNotEquals(application, other);
+        assertNotEquals(application.hashCode(), other.hashCode());
+    }
+
+    @Test
+    void applications_with_the_same_destination_name_are_equal() {
+        Application application = new Application("key", "name");
+        application.setDestination_name("Acme Intranet");
+        Application other = new Application("key", "name");
+        other.setDestination_name("Acme Intranet");
+
+        assertEquals(application, other);
+        assertEquals(application.hashCode(), other.hashCode());
+    }
+
+    @Test
+    void toString_includes_destination_name() {
+        Application application = new Application("key", "name");
+        application.setDestination_name("Acme Intranet");
+
+        assertTrue(application.toString().contains("destination_name=Acme Intranet"));
+    }
+}

--- a/duo-universal-sdk/src/test/java/com/duosecurity/model/ApplicationTest.java
+++ b/duo-universal-sdk/src/test/java/com/duosecurity/model/ApplicationTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ApplicationTest {
 
@@ -16,7 +15,6 @@ class ApplicationTest {
         other.setDestination_name("Acme Payroll");
 
         assertNotEquals(application, other);
-        assertNotEquals(application.hashCode(), other.hashCode());
     }
 
     @Test
@@ -27,14 +25,8 @@ class ApplicationTest {
         other.setDestination_name("Acme Intranet");
 
         assertEquals(application, other);
+        // Equal objects are required to agree on hashCode; unequal ones are not required to
+        // disagree, so there is no matching assertion in the test above.
         assertEquals(application.hashCode(), other.hashCode());
-    }
-
-    @Test
-    void toString_includes_destination_name() {
-        Application application = new Application("key", "name");
-        application.setDestination_name("Acme Intranet");
-
-        assertTrue(application.toString().contains("destination_name=Acme Intranet"));
     }
 }


### PR DESCRIPTION
Adds five optional parameters Duo's authorize endpoint accepts that this SDK could not send, plus the one field Duo returns in response to them. The first three are the Java SDK equivalent of https://github.com/duosecurity/duo_universal_python/pull/42; `max_age` and `prompt` are documented by Duo but aren't in the Python SDK yet.

All five are claims in the signed request JWT:

| Claim | Meaning |
| --- | --- |
| `dest_app_name` | User-facing name of the application the user is authenticating to. Duo shows it in Duo Mobile and records it in the authentication log. |
| `dest_app_id` | Long-lived unique identifier for that application. Not shown to users. |
| `display_username` | Username shown in Duo Mobile's "user" field for Push, in place of the Duo username. Does not change which user Duo authenticates. |
| `max_age` | How many seconds may have passed since the user last authenticated interactively. A remembered session older than this forces interactive reauthentication. |
| `prompt` | `login` forces interactive reauthentication even when a remembered session exists, equivalent to a `max_age` of `0`. |

Duo distinguishes an absent claim from one present with an empty value, so each is omitted from the JWT unless the caller supplies a value. None of the five is validated locally, matching the Python SDK, which validates only username, state and nonce — Duo is the authority on what it accepts.

`max_age` is a boxed `Integer` rather than an `int` so that unset stays distinguishable from `0`, which forces interactive reauthentication rather than meaning "no limit".

## Response field

Duo echoes `dest_app_name` back in the ID token as `auth_context.application.destination_name`, but `Application` only had `key` and `name`, so `Utils.getApplication` was silently dropping it. The other four aren't documented as being returned anywhere in the token, so they need no response-side counterpart.

## API surface

Rather than grow `createAuthUrl` to eight positional arguments — where `destAppName`, `destAppId` and `displayUsername` are easy to transpose with no compile error — this adds `AuthUrlOptions` with a builder:

```java
String authUrl = duoClient.createAuthUrl(
        new AuthUrlOptions.Builder(username, state)
                .setNonce(nonce)
                .setDestAppName("Acme VPN")
                .setDestAppId("vpn-prod-1")
                .setDisplayUsername("a.smith@acme.com")
                .setMaxAge(3600)
                .setPrompt(AuthUrlOptions.Prompt.LOGIN)
                .build());
```

Username and state live inside the options object rather than staying positional. That's what keeps the change source compatible: a three-argument `createAuthUrl(username, state, AuthUrlOptions)` would have made existing `createAuthUrl(username, state, null)` calls ambiguous and stopped them compiling. As written, every existing call shape is untouched:

```java
client.createAuthUrl(username, state);         // unchanged
client.createAuthUrl(username, state, nonce);  // unchanged
client.createAuthUrl(username, state, null);   // still compiles
```

Both existing overloads now delegate to the options path, so the pre-existing nonce and validation tests cover that delegation. The two-argument `Application` constructor is likewise left alone, matching how `Token` handles `amr` and `nonce`.

`prompt` is an `AuthUrlOptions.Prompt` enum, so an unsupported value is a compile error rather than something Duo rejects at runtime.

`Utils.createJwtForAuthUrl` takes the options object for the same reason — it was already at seven positional parameters. It's package private, so only its two callers in `UtilsTest` changed.

## Tests

Thirteen new tests, each watched fail before the implementation existed:

- one per claim reaching the request JWT; the `display_username` test also asserts `duo_uname` is unaffected, since only the displayed name should change
- a `max_age` of `0` is sent rather than swallowed — the case an `if (maxAge > 0)` style check would silently break
- unset options leave the claims out of the JWT entirely
- `createAuthUrl(null)` throws `DuoException("Missing options")` rather than an NPE
- `destination_name` maps out of `auth_context.application`, and is null when Duo omits it
- a new `ApplicationTest` covering `equals` and `hashCode`; the RED here was two applications differing only in `destination_name` comparing equal

The omission test would have passed on arrival, since the null check was written alongside the first claim. It was mutation-verified instead, and again when `max_age` and `prompt` were added to it: emitting the claims unconditionally produced `expected: <true> but was: <false>`.

80 tests pass, checkstyle is clean on both modules, and `mvn install` succeeds.

Also tested manually, modifying the demo app to pass the destination application and display parameters and verifying they flow through the auth as expected.

## Example app

`duo-example` now uses the options form, with a commented block showing the five new setters. Its behavior is unchanged — it sets none of the new values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

